### PR TITLE
fix: better suited ios indicator size

### DIFF
--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -142,6 +142,9 @@ export class Pager extends PagerBase {
         super.initNativeView();
         const nativeView = this.pager;
         nativeView.registerClassForCellWithReuseIdentifier(PagerCell.class(), this._defaultTemplate.key);
+        nativeView.backgroundColor = UIColor.clearColor;
+        nativeView.autoresizesSubviews = false;
+        nativeView.autoresizingMask = 0;
         nativeView.dataSource = this.mDataSource = UICollectionViewDataSourceImpl.initWithOwner(new WeakRef(this));
         nativeView.scrollEnabled = !this.disableSwipe;
         if (this.orientation === 'vertical') {
@@ -263,6 +266,22 @@ export class Pager extends PagerBase {
         }
         this.mIndicatorView.tintColor = UIColor.whiteColor;
         this.mIndicatorView.currentPageTintColor = UIColor.whiteColor;
+
+        switch (value) {
+            case Indicator.None:
+            case Indicator.Worm:
+            case Indicator.Fill:
+            case Indicator.Swap:
+            case Indicator.THIN_WORM:
+            case Indicator.Disabled:
+                this.mIndicatorView.radius = 4;
+                break;
+
+            case Indicator.Flat:
+                this.mIndicatorView.radius = 2;
+                this.mIndicatorView.transform = CGAffineTransformScale(CGAffineTransformIdentity, 0.7, 0.5);
+                break;
+        }
     }
 
     //@ts-ignore


### PR DESCRIPTION
The indicator size on iOS is way too large and looks rather unpleasant in the current plugin implementation. I experimented a lot with the indicator size by manipulating the plugin code. I would appreciate it, if you could merge this pull request. Of course, if you would offer the option to specify the indicator size as input, this would be even better (but I wasn't able to do this).