### PR TITLE
fix: reset pager to index 0 after items change

### DIFF
--- a/src/ui-pager/index.android.ts
+++ b/src/ui-pager/index.android.ts
@@ -274,6 +274,7 @@ export class Pager extends PagerBase {
     private _observableArrayHandler = (args) => {
         if (this.indicatorView && this.showIndicator) {
             this.indicatorView.setCount(this._childrenCount);
+            this.indicatorView.setSelected(args.index);
         }
         if (this.pagerAdapter) {
             switch (args.action) {


### PR DESCRIPTION
Fixes weird stuff that happens when the `items` change. Force reset of selected index to 0 as well as the indicator.