### PR TITLE
fix(android): Children property inheritance is broken for static pager.

### DIFF
--- a/src/ui-pager/index.android.ts
+++ b/src/ui-pager/index.android.ts
@@ -950,6 +950,8 @@ function initStaticPagerStateAdapter() {
 
             sp.nativeView.setLayoutParams(new android.view.ViewGroup.LayoutParams(android.view.ViewGroup.LayoutParams.MATCH_PARENT, android.view.ViewGroup.LayoutParams.MATCH_PARENT));
 
+            owner._realizedItems.set(sp.nativeView, sp);
+
             initPagerViewHolder();
 
             return new PagerViewHolder(new WeakRef(sp), new WeakRef(owner));


### PR DESCRIPTION
I used static pages and came across this problem which seems to be a missing line.
The root of the problem is subviews not being found during `eachChildView` iteration.
