### PR TITLE
fix: Added missing selectedIndexChangedEvent

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,3 @@
 shamefully-hoist=true
+strict-peer-dependencies=false
+loglevel=error

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@
 * [Installation](#installation)
 * [API](#api)
 	* [Properties](#properties)
+  * [Events](#events)
 * [Usage in Angular](#usage-in-angular)
 	* [Examples](#examples)
 * [Usage in React](#usage-in-react)
@@ -107,7 +108,41 @@ Run the following command from the root of your project:
 Pager for NativeScript supports the core ObservableArray module part of the core NativeScript modules collection. Using an ObservableArray instance as a source for Pager will ensure that changes in the source collection will be automatically taken care of by the control.
 ```
 
+### Properties
 
+| Property | Type |
+| - | - |
+| items | `array` or `ItemsSource` 
+| selectedIndex | `number` |
+| canGoRight | `boolean` |
+| canGoLeft | `boolean` |
+| spacing | `PercentLengthType` |
+| peaking | `PercentLengthType` |
+| perPage | `number` |
+| indicator | `string`  ('disable', 'none', 'worm', 'fill', 'swap', 'thin_worm', 'flat')|
+| circularMode | `boolean` |
+| autoPlayDelay | `number` |
+| autoPlay | `boolean` |
+| orientation | `string` ('horizontal' or 'vertical') |
+| autoPlay | `boolean` |
+| disableSwipe | `boolean` |
+| showIndicator | `boolean` |
+| indicatorColor | `Color` or `string` |
+| indicatorSelectedColor | `Color` or `string` |
+
+### Events
+
+| Event | Type |
+| - | - |
+| selectedIndexChange | `{ object: View, propertyName: string, oldValue: any, value: any }` |
+| scroll | `{ object: View, selectedIndex: number, currentPosition: number, scrollX: number, scrollY: number }` |
+| swipe | `{ object: View }` |
+| swipeStart | `{ object: View }` |
+| swipeOver | `{ object: View }` |
+| swipeEnd | `{ object: View }` |
+| loadMoreItems | `{ object: View }` |
+| itemLoading | `{ object: View, android: any, ios: any, index: number, view: View }` |
+| itemDisposing (iOS only) | `{ object: View, android: any, ios: any, index: number, view: View }` |
 
 [](#usage-in-angular)
 

--- a/src/ui-pager/index.android.ts
+++ b/src/ui-pager/index.android.ts
@@ -412,7 +412,7 @@ export class Pager extends PagerBase {
     }
 
     [selectedIndexProperty.setNative](value: number) {
-        if (this.isLoaded && this.isLayoutValid && this.pager) {
+        if (this.isLoaded && this.pager) {
             const index = this.circularMode ? value + 1 : value;
             if (this.pager.getCurrentItem() !== index) {
                 //   this.indicatorView.setInteractiveAnimation(!this.disableAnimation);

--- a/src/ui-pager/index.android.ts
+++ b/src/ui-pager/index.android.ts
@@ -3,10 +3,8 @@ import { KeyedTemplate } from '@nativescript/core/ui/core/view';
 import { isString } from '@nativescript/core/utils/types';
 import { layout } from '@nativescript/core/utils/utils';
 import {
-    ITEMLOADING,
     Indicator,
     ItemEventData,
-    LOADMOREITEMS,
     Orientation,
     PagerBase,
     PagerItem,
@@ -686,7 +684,7 @@ function initPagerChangeCallback() {
                     scrollY: owner.verticalOffset
                 });
                 if (owner.items && position === owner.pagerAdapter.lastIndex() - owner.loadMoreCount) {
-                    owner.notify({ eventName: LOADMOREITEMS, object: owner });
+                    owner.notify({ eventName: Pager.loadMoreItemsEvent, object: owner });
                 }
 
                 if (owner.showIndicator && owner.indicatorView) {
@@ -837,7 +835,7 @@ function initPagerRecyclerAdapter() {
                 }
                 const bindingContext = owner._getDataItem(index);
                 const args = {
-                    eventName: ITEMLOADING,
+                    eventName: Pager.itemLoadingEvent,
                     object: owner,
                     android: holder,
                     ios: undefined,
@@ -961,7 +959,7 @@ function initStaticPagerStateAdapter() {
             const owner = this.owner ? this.owner.get() : null;
             if (owner) {
                 const args = {
-                    eventName: ITEMLOADING,
+                    eventName: Pager.itemLoadingEvent,
                     object: owner,
                     android: holder,
                     ios: undefined,

--- a/src/ui-pager/index.common.ts
+++ b/src/ui-pager/index.common.ts
@@ -96,7 +96,8 @@ export abstract class PagerBase extends ContainerView implements AddChildFromBui
     public circularMode: boolean;
     public autoPlayDelay: number;
     public autoPlay: boolean;
-    public static selectedIndexChangedEvent = 'selectedIndexChanged';
+    // This one works along with existing NS property change event system
+    public static selectedIndexChangeEvent = 'selectedIndexChange';
     public static scrollEvent = 'scroll';
     public static swipeEvent = 'swipe';
     public static swipeStartEvent = 'swipeStart';
@@ -372,14 +373,6 @@ export const selectedIndexProperty = new CoercibleProperty<PagerBase, number>({
     name: 'selectedIndex',
     defaultValue: -1,
     // affectsLayout: global.isIOS,
-    valueChanged: (target, oldValue, newValue) => {
-        target.notify({
-            eventName: PagerBase.selectedIndexChangedEvent,
-            object: target,
-            oldIndex: oldValue,
-            newIndex: newValue
-        });
-    },
     coerceValue: (target, value) => {
         const items = target._childrenCount;
         if (items) {

--- a/src/ui-pager/index.common.ts
+++ b/src/ui-pager/index.common.ts
@@ -28,9 +28,6 @@ import { layout } from '@nativescript/core/utils/utils';
 
 export type Orientation = 'horizontal' | 'vertical';
 
-export const ITEMLOADING = 'itemLoading';
-export const ITEMDISPOSING = 'itemDisposing';
-export const LOADMOREITEMS = 'loadMoreItems';
 export namespace knownTemplates {
     export const itemTemplate = 'itemTemplate';
 }
@@ -106,8 +103,9 @@ export abstract class PagerBase extends ContainerView implements AddChildFromBui
     public static swipeStartEvent = 'swipeStart';
     public static swipeOverEvent = 'swipeOver';
     public static swipeEndEvent = 'swipeEnd';
-    public static loadMoreItemsEvent = LOADMOREITEMS;
-    public static itemLoadingEvent = ITEMLOADING;
+    public static loadMoreItemsEvent = 'loadMoreItems';
+    public static itemLoadingEvent = 'itemLoading';
+    public static itemDisposingEvent = 'itemDisposing';
     public orientation: Orientation;
     public _effectiveItemHeight: number;
     public _effectiveItemWidth: number;

--- a/src/ui-pager/index.common.ts
+++ b/src/ui-pager/index.common.ts
@@ -97,7 +97,6 @@ export abstract class PagerBase extends ContainerView implements AddChildFromBui
     public autoPlayDelay: number;
     public autoPlay: boolean;
     public static selectedIndexChangedEvent = 'selectedIndexChanged';
-    public static selectedIndexChangeEvent = 'selectedIndexChange';
     public static scrollEvent = 'scroll';
     public static swipeEvent = 'swipe';
     public static swipeStartEvent = 'swipeStart';
@@ -373,6 +372,14 @@ export const selectedIndexProperty = new CoercibleProperty<PagerBase, number>({
     name: 'selectedIndex',
     defaultValue: -1,
     // affectsLayout: global.isIOS,
+    valueChanged: (target, oldValue, newValue) => {
+        target.notify({
+            eventName: PagerBase.selectedIndexChangedEvent,
+            object: target,
+            oldIndex: oldValue,
+            newIndex: newValue
+        });
+    },
     coerceValue: (target, value) => {
         const items = target._childrenCount;
         if (items) {

--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -1,11 +1,8 @@
 import { ChangeType, Color, EventData, KeyedTemplate, Observable, ObservableArray, Property, ProxyViewContainer, StackLayout, Utils, View, ViewBase, profile } from '@nativescript/core';
 import { layout } from '@nativescript/core/utils/utils';
 import {
-    ITEMDISPOSING,
-    ITEMLOADING,
     Indicator,
     ItemEventData,
-    LOADMOREITEMS,
     Orientation,
     PagerBase,
     PagerItem,
@@ -641,7 +638,7 @@ export class Pager extends PagerBase {
         let view = cell.view;
 
         const args = {
-            eventName: ITEMDISPOSING,
+            eventName: Pager.itemDisposingEvent,
             object: this,
             index,
             android: undefined,
@@ -743,7 +740,7 @@ export class Pager extends PagerBase {
             }
             const bindingContext = this._getDataItem(indexPath.row);
             const args = {
-                eventName: ITEMLOADING,
+                eventName: Pager.itemLoadingEvent,
                 object: this,
                 index,
                 android: undefined,
@@ -931,7 +928,7 @@ class UICollectionDelegateImpl extends NSObject implements UICollectionViewDeleg
             }
             if (owner.items && indexPath.row === owner.lastIndex - owner.loadMoreCount) {
                 owner.notify<EventData>({
-                    eventName: LOADMOREITEMS,
+                    eventName: Pager.loadMoreItemsEvent,
                     object: owner
                 });
             }


### PR DESCRIPTION
Added missing notify for selectedIndexChangedEvent using the same logic as in ui-material-tabs.

An old android-specific check for layout validity seemed to cause problems with this new event, so I removed it.
For example, if one somehow triggers a layout update inside `selectedIndexChanged` event callback, navigation gets blocked.
It was added here but the reason is not clear: https://github.com/triniwiz/nativescript-pager/commit/21766c6f30164520872d461514032ac9bf31ee40