### PR TITLE
fix ios array and not found nativeTransformer

### DIFF
--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -1116,18 +1116,15 @@ class UICollectionViewFlowLinearLayoutImpl extends UICollectionViewFlowLayout {
     public layoutAttributesForElementsInRect(rect: CGRect) {
         const owner = this._owner ? this._owner.get() : null;
         const originalLayoutAttribute = super.layoutAttributesForElementsInRect(rect);
-        const visibleLayoutAttributes = [];
+        const visibleLayoutAttributes = NSMutableArray.alloc().init();
         if (owner && owner.transformers) {
-            const transformsArray = owner.transformers
-                .split(' ')
-                .map((s) => Pager.mRegisteredTransformers[s])
-                .filter((s) => !!s);
+            const transformsArray = owner.transformers.split(' ');
             if (transformsArray.length) {
                 const collectionView = this.collectionView;
                 const count = originalLayoutAttribute.count;
                 for (let i = 0; i < count; i++) {
                     const attributes = originalLayoutAttribute.objectAtIndex(i);
-                    visibleLayoutAttributes[i] = attributes;
+                    visibleLayoutAttributes.addObject(attributes);
                     for (const transformer of transformsArray) {
                         const nativeTransformer = Pager.mRegisteredTransformers[transformer];
                         if (nativeTransformer) {


### PR DESCRIPTION
@farfromrefug  There were 2 errors:
- When returning visibleLayoutAttributes the app would crash on ios
- [This](https://github.com/nativescript-community/ui-pager/compare/fix-ios-custom-transformer?expand=1#diff-a1f07773b050f8aabe7ab46b4724e3ba43f7069f993736a1c6d32f085a1a8d84L1123-L1124) made me not find `const nativeTransformer = Pager.mRegisteredTransformers[transformer];` later