### PR TITLE
fix[ios]: change selectedIndex with transformer break design

### DIFF
--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -380,6 +380,7 @@ export class Pager extends PagerBase {
         }
         // dispatch_async(main_queue, () => {
         if (this.mDataSource.collectionViewNumberOfItemsInSection(this.nativeViewProtected, 0) > maxMinIndex) {
+            this.nativeViewProtected.setContentOffsetAnimated(CGPointMake(1,  0), !!animate)
             this.nativeViewProtected.scrollToItemAtIndexPathAtScrollPositionAnimated(
                 NSIndexPath.indexPathForItemInSection(maxMinIndex, 0),
                 this.orientation === 'vertical' ? UICollectionViewScrollPosition.CenteredVertically : UICollectionViewScrollPosition.CenteredHorizontally,

--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -380,7 +380,7 @@ export class Pager extends PagerBase {
         }
         // dispatch_async(main_queue, () => {
         if (this.mDataSource.collectionViewNumberOfItemsInSection(this.nativeViewProtected, 0) > maxMinIndex) {
-            this.nativeViewProtected.setContentOffsetAnimated(CGPointMake(1,  0), !!animate)
+            this.nativeViewProtected.setContentOffsetAnimated(CGPointMake(1, 0), !!animate)
             this.nativeViewProtected.scrollToItemAtIndexPathAtScrollPositionAnimated(
                 NSIndexPath.indexPathForItemInSection(maxMinIndex, 0),
                 this.orientation === 'vertical' ? UICollectionViewScrollPosition.CenteredVertically : UICollectionViewScrollPosition.CenteredHorizontally,

--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -380,6 +380,8 @@ export class Pager extends PagerBase {
         }
         // dispatch_async(main_queue, () => {
         if (this.mDataSource.collectionViewNumberOfItemsInSection(this.nativeViewProtected, 0) > maxMinIndex) {
+            // when we have custom layouts (they don't occupy 100% of the parent) and we use custom transformers we need to call setContentOffsetAnimated to take size into account. 
+            // Reference: https://stackoverflow.com/a/53798708/6015400
             this.nativeViewProtected.setContentOffsetAnimated(CGPointMake(1, 0), !!animate);
             this.nativeViewProtected.scrollToItemAtIndexPathAtScrollPositionAnimated(
                 NSIndexPath.indexPathForItemInSection(maxMinIndex, 0),

--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -380,7 +380,7 @@ export class Pager extends PagerBase {
         }
         // dispatch_async(main_queue, () => {
         if (this.mDataSource.collectionViewNumberOfItemsInSection(this.nativeViewProtected, 0) > maxMinIndex) {
-            this.nativeViewProtected.setContentOffsetAnimated(CGPointMake(1, 0), !!animate)
+            this.nativeViewProtected.setContentOffsetAnimated(CGPointMake(1, 0), !!animate);
             this.nativeViewProtected.scrollToItemAtIndexPathAtScrollPositionAnimated(
                 NSIndexPath.indexPathForItemInSection(maxMinIndex, 0),
                 this.orientation === 'vertical' ? UICollectionViewScrollPosition.CenteredVertically : UICollectionViewScrollPosition.CenteredHorizontally,


### PR DESCRIPTION
@farfromrefug  Now when you scroll to an item with a width/height other than 100% and have a custom transformer the item is centered vertically or horizontally on the screen.

Reference: https://stackoverflow.com/a/53798708/6015400

Close: https://github.com/nativescript-community/ui-pager/issues/31

Note: I don't know why it is worth 1 and 0 but it is working for horizontal and vertical pagers