### PR TITLE
use Array.isArray instead of ɵisListLikeIterable which is deprecated

### DIFF
--- a/src/ui-pager/angular/pager-items-comp.ts
+++ b/src/ui-pager/angular/pager-items-comp.ts
@@ -18,8 +18,7 @@ import {
     Output,
     TemplateRef,
     ViewChild,
-    ViewContainerRef,
-    ɵisListLikeIterable as isListLikeIterable
+    ViewContainerRef
 } from '@angular/core';
 import { Pager, PagerError, PagerItem, PagerLog } from '@nativescript-community/ui-pager';
 import { extractSingleViewRecursive, isInvisibleNode, registerElement } from '@nativescript/angular';
@@ -86,7 +85,7 @@ export abstract class TemplatedItemsComponent implements DoCheck, OnDestroy, Aft
         if (value instanceof ObservableArray) {
             needDiffer = false;
         }
-        if (needDiffer && !this._differ && isListLikeIterable(value)) {
+        if (needDiffer && !this._differ && Array.isArray(value)) {
             this._differ = this._iterableDiffers.find(this._items).create((_index, item) => item);
         }
 


### PR DESCRIPTION
This PR addresses bug #34 by fixing the issue `ɵisListLikeIterable` which is imported from `@angular/core` and is deprecated in latest versions.