### PR TITLE
fix(ios): Layout children when reusing cell

### DIFF
--- a/src/ui-pager/index.ios.ts
+++ b/src/ui-pager/index.ios.ts
@@ -1146,7 +1146,7 @@ class UICollectionViewDataSourceImpl extends NSObject implements UICollectionVie
             const cellView: any = (cell as PagerCell).view;
             cellView.iosOverflowSafeArea = owner.iosOverflowSafeArea;
             cellView['iosIgnoreSafeArea'] = owner['iosIgnoreSafeArea'];
-            if (!owner.iosOverflowSafeAreaEnabled && cellView && cellView.isLayoutRequired) {
+            if (cellView && cellView.isLayoutRequired) {
                 View.layoutChild(owner, cellView, 0, 0, Utils.layout.toDevicePixels(size.width), Utils.layout.toDevicePixels(size.height));
             }
         }


### PR DESCRIPTION
If you have for example a Label that on slide 4 becomes two lines where as on slide 1-3 it is one line, when slide 4 is shown it will be truncated because the the view has not been re-layed out for the new data.

If on line:
https://github.com/nativescript-community/ui-pager/blob/443ac1b6aa528b3e0a9c9e60906bc7edf56c3995/src/ui-pager/index.ios.ts#L1149

The check for iosOverflowSafeAreaEnabled  is removed, then the `View.layoutChild` is called and all appears to be well.
