### PR TITLE
fix(angular): Correct initialisation issue with angular

### DIFF
--- a/src/ui-pager/angular/index.ts
+++ b/src/ui-pager/angular/index.ts
@@ -22,8 +22,6 @@ export class PagerComponent extends TemplatedItemsComponent {
     public get nativeElement(): Pager {
         return this.templatedItemsView;
     }
-    //@ts-ignore
-    protected templatedItemsView: Pager;
 
     constructor(_elementRef: ElementRef, _iterableDiffers: IterableDiffers) {
         super(_elementRef, _iterableDiffers);


### PR DESCRIPTION
Moving to the later angular versions forces es2022 and useDefineForClassFields = false causing the member templatedItemsView not to be initialised correctly, causing a crash in all versions since 14.1.10.

No need to override the member here.

Fixes the error at runtime:
```
  ERROR TypeError: Cannot set properties of undefined (setting 'items')
  ERROR TypeError: Cannot read properties of undefined (reading 'refresh')
```

Fixes Issue:  #56 