### PR TITLE
fix(ui-pager): Method getChildView returns placeholder

### DIFF
--- a/src/ui-pager/index.android.ts
+++ b/src/ui-pager/index.android.ts
@@ -161,7 +161,12 @@ export class Pager extends PagerBase {
         if (this._childrenViews) {
             return this._childrenViews[index]?.view;
         }
-        return this.enumerateViewHolders<View>((v) => (v.getAdapterPosition() === index ? v.view : undefined));
+        return this.enumerateViewHolders<View>((v) => {
+            if (v.getAdapterPosition() === index) {
+                return v.view[PLACEHOLDER] === true ? (v.view as ContentView).content : v.view;
+            }
+            return undefined;
+        });
     }
 
     protected _removeChildView(index: number) {


### PR DESCRIPTION
This PR fixes android ui-pager method `getChildView` which currently returns the view placeholder instead of template view.